### PR TITLE
fix: cancel BidListing with not bids are skipped

### DIFF
--- a/Bukkit/src/main/java/info/preva1l/fadah/records/listing/ImplBidListing.java
+++ b/Bukkit/src/main/java/info/preva1l/fadah/records/listing/ImplBidListing.java
@@ -228,7 +228,7 @@ public final class ImplBidListing extends ActiveListing implements BidListing {
 
     @Override
     protected void cancel0(@NotNull Player canceller) {
-        if (ZERO_UUID.equals(this.getCurrentBid().bidder())) {
+        if (!ZERO_UUID.equals(this.getCurrentBid().bidder())) {
             Bid lastBid = bids.first();
             getCurrency().add(Bukkit.getOfflinePlayer(lastBid.bidder()),  lastBid.bidAmount());
         }

--- a/Bukkit/src/main/java/info/preva1l/fadah/records/listing/ImplBidListing.java
+++ b/Bukkit/src/main/java/info/preva1l/fadah/records/listing/ImplBidListing.java
@@ -228,8 +228,10 @@ public final class ImplBidListing extends ActiveListing implements BidListing {
 
     @Override
     protected void cancel0(@NotNull Player canceller) {
-        Bid lastBid = bids.first();
-        getCurrency().add(Bukkit.getOfflinePlayer(lastBid.bidder()),  lastBid.bidAmount());
+        if (ZERO_UUID.equals(this.getCurrentBid().bidder())) {
+            Bid lastBid = bids.first();
+            getCurrency().add(Bukkit.getOfflinePlayer(lastBid.bidder()),  lastBid.bidAmount());
+        }
         super.cancel0(canceller);
     }
 


### PR DESCRIPTION
If the Bid Listing not has any bids this fails, the error its not logged because its used in a try-catch with not notice.